### PR TITLE
feat: checkbox for cleaning input dirs (#7)

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,6 +24,7 @@ def get_args():
 	parser.add_argument('--decensor_input_path', default='./decensor_input/', help='input images with censored regions colored green to be decensored by decensor.py path')
 	parser.add_argument('--decensor_input_original_path', default='./decensor_input_original/', help='input images with no modifications to be decensored by decensor.py path')
 	parser.add_argument('--decensor_output_path', default='./decensor_output/', help='output images generated from running decensor.py path')
+	parser.add_argument('--clean-up-input-dirs', dest='clean_up_input_dirs', action='store_true', default=False, help='whether to delete all image files in the input directories when decensoring is done')
 
 	#Decensor settings
 	parser.add_argument('--mask_color_red', default=0, help='red channel of mask color in decensoring')

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@
 # The greater the number of variations, the longer decensoring process will be.
 
 import sys, time
-from PySide2.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QGridLayout, QGroupBox, QDesktopWidget, QApplication
+from PySide2.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QGridLayout, QGroupBox, QDesktopWidget, QApplication, QCheckBox
 from PySide2.QtWidgets import QAction, qApp, QApplication, QMessageBox, QRadioButton, QPushButton, QTextEdit, QLabel
 from PySide2.QtWidgets import QSizePolicy,QMainWindow, QStatusBar, QProgressBar
 from PySide2.QtCore import Qt, QObject
@@ -23,8 +23,8 @@ class MainWindow(QWidget):
 		super().__init__()
 		self.signals = Signals()
 		self.initUI()
-		self.setSignals()
 		self.decensor = Decensor(self)
+		self.setSignals()
 		self.load_model()
 
 	def initUI(self):
@@ -94,14 +94,19 @@ class MainWindow(QWidget):
 		self.statusBar.addWidget(self.statusLabel, 1)
 		self.statusBar.addWidget(self.progressBar, 2)
 
+		self.cleanInputDirectoryCheckbox = QCheckBox(
+			'Clean up input directories after decensoring'
+		)
+
 		#put all groups into grid
 		# addWidget(row, column, rowSpan, columnSpan)
 		grid_layout.addWidget(self.tutorialLabel, 0, 0, 1, 2)
 		grid_layout.addWidget(self.censorTypeGroupBox, 1, 0, 1, 1)
 		grid_layout.addWidget(self.variationsGroupBox, 1, 1, 1, 1)
-		grid_layout.addWidget(self.decensorButton, 2, 0, 1, 2)
-		grid_layout.addWidget(self.progressMessage, 3, 0, 1, 2)
-		grid_layout.addWidget(self.statusBar, 4, 0, 1, 2)
+		grid_layout.addWidget(self.cleanInputDirectoryCheckbox, 2, 0, 1, 2)
+		grid_layout.addWidget(self.decensorButton, 3, 0, 1, 2)
+		grid_layout.addWidget(self.progressMessage, 4, 0, 1, 2)
+		grid_layout.addWidget(self.statusBar, 5, 0, 1, 2)
 
 		#window size settings
 		self.resize(900, 600)
@@ -128,6 +133,9 @@ class MainWindow(QWidget):
 		self.signals.insertText_progressCursor.connect(self.progressMessage.append)
 		self.signals.clear_progressMessage.connect(self.progressMessage.clear)
 		self.signals.appendText_progressMessage.connect(self.progressMessage.append)
+		self.signals.update_clean_up_input_dirs_flag.connect(
+			self.decensor.set_clean_up_input_dirs
+		)
 
 	def decensorClicked(self):
 		self.decensorButton.setEnabled(False)
@@ -158,6 +166,9 @@ class MainWindow(QWidget):
 				variations = int(vb.text())
 		self.decensor.variations = variations
 
+		self.signals.update_clean_up_input_dirs_flag.emit(
+			self.cleanInputDirectoryCheckbox.isChecked()
+		)
 
 		self.decensorButton.setEnabled(False)
 		self.decensor.start()

--- a/signals.py
+++ b/signals.py
@@ -40,3 +40,5 @@ class Signals(QtCore.QObject):
     # str : value to change
     # direct connect to self.progressMessage.append(str)
     appendText_progressMessage = QtCore.Signal(str)
+
+    update_clean_up_input_dirs_flag = QtCore.Signal(bool)


### PR DESCRIPTION
This update adds a checkbox to the main window. If checked, it cleans up all the files in input directories (`decensor_input/` and also `decensor_input_original/` in case if it deals with mosaic censorship).

![image](https://github.com/user-attachments/assets/f26c0b57-878d-4864-b468-7e81aced9e81)

Similar to what we had in https://github.com/Deepshift/DeepCreamPy/issues/7 (credits to @ghost), but as a checkbox. 
And it cleans only input directory, not decensor_ouput (cause i'm not really sure about how to design it, i mean i can add a button like "Remove all pictures in `decensor_output/`", but it's purpose would be quite obscure; maybe we should rather add setting output directory via UI).
___
CC: @naphteine
___

* (feat) add a checkbox in `MainWindow` to enable cleaning input directories after processing images.
* (feat) add `clean_up_input_dirs` flag attribute in `Decensor` class to manage the cleanup operation.
* (feat) add `clean_input_directories()` method in `Decensor` to remove `.png`, `.jpg`, and `.jpeg` files from input directories.
* (feat) add `do_post_jobs()` method being called after decensoring process is completed (later we can put here any other logic for post-processing as well).
* (feat) integrated logic to set `clean_up_input_dirs` via a signal emitted from `MainWindow`.